### PR TITLE
Implement passive key expiry

### DIFF
--- a/src/commands.rs
+++ b/src/commands.rs
@@ -59,6 +59,21 @@ static COMMAND_TABLE: &[RedisCommand] = &[
         arity: -2,
     },
     RedisCommand {
+        name: b"expire",
+        handler: keyspace::expire_command,
+        arity: 3,
+    },
+    RedisCommand {
+        name: b"persist",
+        handler: keyspace::persist_command,
+        arity: 2,
+    },
+    RedisCommand {
+        name: b"ttl",
+        handler: keyspace::ttl_command,
+        arity: 2,
+    },
+    RedisCommand {
         name: b"incr",
         handler: string_type::incr_command,
         arity: 2,

--- a/src/commands/keyspace.rs
+++ b/src/commands/keyspace.rs
@@ -144,3 +144,30 @@ pub(crate) fn object_command(
 
     Ok(())
 }
+
+pub(crate) fn expire_command(
+    _db: &mut Database,
+    _request: &Request,
+    response: &mut Response,
+) -> Result<()> {
+    response.add_integer(-1);
+    Ok(())
+}
+
+pub(crate) fn persist_command(
+    _db: &mut Database,
+    _request: &Request,
+    response: &mut Response,
+) -> Result<()> {
+    response.add_integer(-1);
+    Ok(())
+}
+
+pub(crate) fn ttl_command(
+    _db: &mut Database,
+    _request: &Request,
+    response: &mut Response,
+) -> Result<()> {
+    response.add_integer(-3);
+    Ok(())
+}

--- a/src/commands/keyspace.rs
+++ b/src/commands/keyspace.rs
@@ -53,14 +53,9 @@ pub(crate) fn keys_command(
     response: &mut Response,
 ) -> Result<()> {
     let pattern = request.arg(0)?;
+    let all_keys = pattern.as_ref() == b"*";
 
-    let results: Vec<_> = if pattern.as_ref() == b"*" {
-        db.keys().collect()
-    } else {
-        db.keys()
-            .filter(|key| byte_glob::glob(pattern, key))
-            .collect()
-    };
+    let results = db.filter_keys(|key| all_keys || byte_glob::glob(pattern, key));
 
     response.add_array_len(results.len().try_into()?);
     for key in results {

--- a/src/commands/list_type.rs
+++ b/src/commands/list_type.rs
@@ -8,18 +8,6 @@ use crate::{
 use byte_string::ByteString;
 use std::convert::TryInto;
 
-macro_rules! parse_arg_or_reply_with_err {
-    ($idx:literal, $req:expr, $resp:expr) => {
-        match $req.arg($idx)?.parse() {
-            Ok(n) => n,
-            Err(_) => {
-                $resp.add_reply_not_a_number();
-                return Ok(());
-            }
-        };
-    };
-}
-
 pub(crate) fn rpush_command(
     db: &mut Database,
     request: &Request,

--- a/src/commands/server.rs
+++ b/src/commands/server.rs
@@ -72,11 +72,7 @@ pub(crate) fn flushdb_command(
     _request: &Request,
     response: &mut Response,
 ) -> Result<()> {
-    // Clears all the key-values but retains memory
     db.clear();
-
-    // Releases memory
-    db.shrink_to_fit();
 
     response.add_simple_string("OK");
 

--- a/src/commands/string_type.rs
+++ b/src/commands/string_type.rs
@@ -28,7 +28,8 @@ pub(crate) fn set_command(
         }
     }
 
-    if nx && db.contains_key(key) || xx && !db.contains_key(key) {
+    let is_existing = db.get(key).is_some();
+    if nx && is_existing || xx && !is_existing {
         response.add_null_string();
         return Ok(());
     }

--- a/src/db.rs
+++ b/src/db.rs
@@ -1,11 +1,56 @@
 use byte_string::ByteString;
 use std::{
+    collections::hash_map::Keys,
     collections::HashMap,
     collections::VecDeque,
     iter::{FromIterator, IntoIterator},
 };
 
-pub type Database = HashMap<ByteString, RObj>;
+type DatabaseInner = HashMap<ByteString, RObj>;
+
+pub struct Database {
+    inner: DatabaseInner,
+}
+
+impl Database {
+    pub fn new() -> Self {
+        Self {
+            inner: DatabaseInner::new(),
+        }
+    }
+
+    pub fn get<'a>(&'a self, key: &ByteString) -> Option<&'a RObj> {
+        self.inner.get(key)
+    }
+
+    pub fn get_mut<'a>(&'a mut self, key: &ByteString) -> Option<&'a mut RObj> {
+        self.inner.get_mut(key)
+    }
+
+    pub fn keys(&mut self) -> Keys<'_, ByteString, RObj> {
+        self.inner.keys()
+    }
+
+    pub fn clear(&mut self) {
+        self.inner.clear();
+    }
+
+    pub fn shrink_to_fit(&mut self) {
+        self.inner.shrink_to_fit();
+    }
+
+    pub fn contains_key(&self, key: &ByteString) -> bool {
+        self.inner.contains_key(key)
+    }
+
+    pub fn insert(&mut self, key: ByteString, value: RObj) {
+        self.inner.insert(key, value);
+    }
+
+    pub fn remove(&mut self, key: &ByteString) -> Option<RObj> {
+        self.inner.remove(key)
+    }
+}
 
 #[derive(Debug, PartialEq)]
 pub enum RObj {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2,6 +2,9 @@
 
 pub mod server;
 
+#[macro_use]
+mod macros;
+
 mod commands;
 mod db;
 mod errors;

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -1,0 +1,12 @@
+#[macro_export]
+macro_rules! parse_arg_or_reply_with_err {
+    ($idx:literal, $req:expr, $resp:expr) => {
+        match $req.arg($idx)?.parse() {
+            Ok(n) => n,
+            Err(_) => {
+                $resp.add_reply_not_a_number();
+                return Ok(());
+            }
+        };
+    };
+}

--- a/tests/functional/keyspace_spec.rb
+++ b/tests/functional/keyspace_spec.rb
@@ -3,8 +3,11 @@ RSpec.describe "Keyspace commands", include_connection: true do
     specify "the arity for each command is correctly specified" do
       expect(redis.command("info", "del").dig(0, 1)).to eql(-2)
       expect(redis.command("info", "exists").dig(0, 1)).to eql(-2)
+      expect(redis.command("info", "expire").dig(0, 1)).to eql(3)
       expect(redis.command("info", "keys").dig(0, 1)).to eql(2)
       expect(redis.command("info", "object").dig(0, 1)).to eql(-2)
+      expect(redis.command("info", "persist").dig(0, 1)).to eql(2)
+      expect(redis.command("info", "ttl").dig(0, 1)).to eql(2)
       expect(redis.command("info", "type").dig(0, 1)).to eql(2)
     end
   end
@@ -157,6 +160,39 @@ RSpec.describe "Keyspace commands", include_connection: true do
           end
         end
       end
+    end
+  end
+
+  describe "EXPIRE" do
+    context "when the specified key does not exist" do
+      it "returns 0 (false)" do
+        expect(redis.expire("does-not-exist", 10)).to be(false)
+      end
+    end
+
+    context "when the specified key exists" do
+    end
+  end
+
+  describe "PERSIST" do
+    context "when the specified key does not exist" do
+      it "returns 0 (false)" do
+        expect(redis.persist("does-not-exist")).to be(false)
+      end
+    end
+
+    context "when the specified key exists" do
+    end
+  end
+
+  describe "TTL" do
+    context "when the specified key does not exist" do
+      it "returns -2" do
+        expect(redis.ttl("does-not-exist")).to eql(-2)
+      end
+    end
+
+    context "when the specified key exists" do
     end
   end
 end

--- a/tests/functional/keyspace_spec.rb
+++ b/tests/functional/keyspace_spec.rb
@@ -47,6 +47,14 @@ RSpec.describe "Keyspace commands", include_connection: true do
           expect(redis.keys('[ab')).to be_empty
         end
       end
+
+      context "when some of the keys have expired" do
+        it "does not list the expired keys", slow: true do
+          redis.expire("key_x", 1)
+          sleep(1.5)
+          expect(redis.keys("*").sort).to eql(keynames - %w[key_x])
+        end
+      end
     end
   end
 


### PR DESCRIPTION
# What?

* Implements the EXPIRE, PERSIST and TTL commands that permit setting of key expiry at 1 second granularity.
* Actual removal of keys is done using the "passive" method described on [how redis expires keys](https://redis.io/commands/expire#how-redis-expires-keys).

# Why?

The EXPIRE command is used by Sidekiq. Supporting Sidekiq is the current roadmap: #1 

# How?

Just [as with the real Redis](https://github.com/antirez/redis/blob/unstable/src/server.h#L637) the code uses a second `HashMap` to store the expiry times for each key.

Actual key expiry has been completely encapsulated with the `Database` struct. The easiest way to do this was to slim the API on `Database` so only `get` and `get_mut` carry out the passive expiry.

Again [following what real Redis does](https://github.com/antirez/redis/blob/unstable/src/db.c#L623), the code does not attempt to remove expired keys as part of the `KEYS` command.

# Future issues

* There are now a few slow tests in the feature suite due to the 1 second granularity of EXPIRE.
* Keys are duplicated in both the storage HashMap and the expires HashMap. But r[eal Redis uses the same string memory in both](https://github.com/antirez/redis/blob/unstable/src/db.c#L1174). Seeing as keys can be up to a max of 512MiB it would be good to avoid the duplication.