### PR TITLE
Implement Hash type with a subset of commands

### DIFF
--- a/benches/clone-vs-real.sh
+++ b/benches/clone-vs-real.sh
@@ -1,6 +1,6 @@
 #!/bin/sh
 
-benches="set,get,incr,lpush,rpush,lpop,rpop,lrange"
+benches="set,get,incr,lpush,rpush,lpop,rpop,lrange,hset"
 opts="-q"
 
 redis-cli flushdb

--- a/src/commands.rs
+++ b/src/commands.rs
@@ -3,6 +3,7 @@ use crate::{
 };
 use byte_string::ByteStr;
 
+mod hash_type;
 mod keyspace;
 mod list_type;
 mod server;
@@ -147,6 +148,31 @@ static COMMAND_TABLE: &[RedisCommand] = &[
         name: b"lrem",
         handler: list_type::lrem_command,
         arity: 4,
+    },
+    RedisCommand {
+        name: b"hset",
+        handler: hash_type::hset_command,
+        arity: -4,
+    },
+    RedisCommand {
+        name: b"hget",
+        handler: hash_type::hget_command,
+        arity: 3,
+    },
+    RedisCommand {
+        name: b"hmset",
+        handler: hash_type::hmset_command,
+        arity: -4,
+    },
+    RedisCommand {
+        name: b"hmget",
+        handler: hash_type::hmget_command,
+        arity: -3,
+    },
+    RedisCommand {
+        name: b"hgetall",
+        handler: hash_type::hgetall_command,
+        arity: 2,
     },
     RedisCommand {
         name: b"command",

--- a/src/commands/hash_type.rs
+++ b/src/commands/hash_type.rs
@@ -124,15 +124,20 @@ pub(crate) fn hgetall_command(
     response: &mut Response,
 ) -> Result<()> {
     let key = request.arg(0)?;
-    let _values = &request.arguments()[1..];
 
     match db.get(key) {
-        Some(RObj::Hash(ref _hash)) => {
-            response.add_integer(0);
+        Some(RObj::Hash(ref hash)) => {
+            let len: i64 = hash.len().try_into()?;
+            response.add_array_len(len * 2);
+
+            for (key, value) in hash {
+                response.add_bulk_string(key);
+                response.add_bulk_string(value);
+            }
         }
         Some(_) => response.add_reply_wrong_type(),
         None => {
-            response.add_integer(0);
+            response.add_array_len(0);
         }
     }
 

--- a/src/commands/hash_type.rs
+++ b/src/commands/hash_type.rs
@@ -1,0 +1,112 @@
+use crate::{
+    db::{Database, RObj},
+    errors::Result,
+    request::Request,
+    response::Response,
+    response_ext::ResponseExt,
+};
+
+pub(crate) fn hset_command(
+    db: &mut Database,
+    request: &Request,
+    response: &mut Response,
+) -> Result<()> {
+    let key = request.arg(0)?;
+    let _values = &request.arguments()[1..];
+
+    match db.get_mut(key) {
+        Some(RObj::Hash(ref mut _hash)) => {
+            response.add_integer(0);
+        }
+        Some(_) => response.add_reply_wrong_type(),
+        None => {
+            response.add_integer(0);
+        }
+    }
+
+    Ok(())
+}
+
+pub(crate) fn hmset_command(
+    db: &mut Database,
+    request: &Request,
+    response: &mut Response,
+) -> Result<()> {
+    let key = request.arg(0)?;
+    let _values = &request.arguments()[1..];
+
+    match db.get_mut(key) {
+        Some(RObj::Hash(ref mut _hash)) => {
+            response.add_integer(0);
+        }
+        Some(_) => response.add_reply_wrong_type(),
+        None => {
+            response.add_integer(0);
+        }
+    }
+
+    Ok(())
+}
+
+pub(crate) fn hget_command(
+    db: &mut Database,
+    request: &Request,
+    response: &mut Response,
+) -> Result<()> {
+    let key = request.arg(0)?;
+    let _values = &request.arguments()[1..];
+
+    match db.get(key) {
+        Some(RObj::Hash(ref _hash)) => {
+            response.add_integer(0);
+        }
+        Some(_) => response.add_reply_wrong_type(),
+        None => {
+            response.add_integer(0);
+        }
+    }
+
+    Ok(())
+}
+
+pub(crate) fn hmget_command(
+    db: &mut Database,
+    request: &Request,
+    response: &mut Response,
+) -> Result<()> {
+    let key = request.arg(0)?;
+    let _values = &request.arguments()[1..];
+
+    match db.get(key) {
+        Some(RObj::Hash(ref _hash)) => {
+            response.add_integer(0);
+        }
+        Some(_) => response.add_reply_wrong_type(),
+        None => {
+            response.add_integer(0);
+        }
+    }
+
+    Ok(())
+}
+
+pub(crate) fn hgetall_command(
+    db: &mut Database,
+    request: &Request,
+    response: &mut Response,
+) -> Result<()> {
+    let key = request.arg(0)?;
+    let _values = &request.arguments()[1..];
+
+    match db.get(key) {
+        Some(RObj::Hash(ref _hash)) => {
+            response.add_integer(0);
+        }
+        Some(_) => response.add_reply_wrong_type(),
+        None => {
+            response.add_integer(0);
+        }
+    }
+
+    Ok(())
+}

--- a/src/commands/hash_type.rs
+++ b/src/commands/hash_type.rs
@@ -5,6 +5,8 @@ use crate::{
     response::Response,
     response_ext::ResponseExt,
 };
+use byte_string::ByteString;
+use std::{collections::HashMap, convert::TryInto};
 
 pub(crate) fn hset_command(
     db: &mut Database,
@@ -12,15 +14,58 @@ pub(crate) fn hset_command(
     response: &mut Response,
 ) -> Result<()> {
     let key = request.arg(0)?;
-    let _values = &request.arguments()[1..];
+    let values = &request.arguments()[1..];
+
+    if values.len() % 2 != 0 {
+        // Note: HSET and HMSET are the handled by the same function in Redis
+        // and the error seems to assume the command is HMSET
+        response.add_error("ERR wrong number of arguments for HMSET");
+        return Ok(());
+    }
 
     match db.get_mut(key) {
-        Some(RObj::Hash(ref mut _hash)) => {
-            response.add_integer(0);
+        Some(RObj::Hash(ref mut hash)) => {
+            let prev_len = hash.len();
+            let new_hash = values
+                .chunks(2)
+                .map(|pair| (pair[0].clone(), pair[1].clone()));
+            hash.extend(new_hash);
+
+            let count_keys_added = hash.len() - prev_len;
+            response.add_integer(count_keys_added.try_into()?);
         }
         Some(_) => response.add_reply_wrong_type(),
         None => {
-            response.add_integer(0);
+            let new_hash = values
+                .chunks(2)
+                .map(|pair| (pair[0].clone(), pair[1].clone()))
+                .collect::<HashMap<ByteString, ByteString>>();
+            let count_keys_added = new_hash.len();
+            db.insert(key.clone(), RObj::Hash(new_hash));
+
+            response.add_integer(count_keys_added.try_into()?);
+        }
+    }
+
+    Ok(())
+}
+
+pub(crate) fn hget_command(
+    db: &mut Database,
+    request: &Request,
+    response: &mut Response,
+) -> Result<()> {
+    let key = request.arg(0)?;
+    let hash_key = request.arg(1)?;
+
+    match db.get(key) {
+        Some(RObj::Hash(ref hash)) => match hash.get(hash_key) {
+            Some(value) => response.add_bulk_string(value),
+            _ => response.add_null_string(),
+        },
+        Some(_) => response.add_reply_wrong_type(),
+        None => {
+            response.add_null_string();
         }
     }
 
@@ -37,27 +82,6 @@ pub(crate) fn hmset_command(
 
     match db.get_mut(key) {
         Some(RObj::Hash(ref mut _hash)) => {
-            response.add_integer(0);
-        }
-        Some(_) => response.add_reply_wrong_type(),
-        None => {
-            response.add_integer(0);
-        }
-    }
-
-    Ok(())
-}
-
-pub(crate) fn hget_command(
-    db: &mut Database,
-    request: &Request,
-    response: &mut Response,
-) -> Result<()> {
-    let key = request.arg(0)?;
-    let _values = &request.arguments()[1..];
-
-    match db.get(key) {
-        Some(RObj::Hash(ref _hash)) => {
             response.add_integer(0);
         }
         Some(_) => response.add_reply_wrong_type(),

--- a/src/commands/keyspace.rs
+++ b/src/commands/keyspace.rs
@@ -77,6 +77,7 @@ pub(crate) fn type_command(
             let type_name = match value {
                 RObj::Int(_) | RObj::String(_) => "string",
                 RObj::List(_) => "list",
+                RObj::Hash(_) => "hash",
             };
 
             response.add_simple_string(type_name);
@@ -122,6 +123,7 @@ pub(crate) fn object_command(
                             RObj::Int(_) => "int",
                             RObj::String(_) => "byte_string",
                             RObj::List(_) => "vecdeque",
+                            RObj::Hash(_) => "hash_map",
                         };
 
                         response.add_bulk_string(type_name);

--- a/src/db.rs
+++ b/src/db.rs
@@ -102,6 +102,7 @@ pub enum RObj {
     Int(i64),
     String(ByteString),
     List(VecDeque<ByteString>),
+    Hash(HashMap<ByteString, ByteString>),
 }
 
 impl From<i64> for RObj {

--- a/tests/functional/hash_type_spec.rb
+++ b/tests/functional/hash_type_spec.rb
@@ -1,0 +1,30 @@
+RSpec.describe "Hash commands", include_connection: true do
+  describe "arity" do
+    specify "the arity for each command is correctly specified" do
+      expect(redis.command("info", "hset").dig(0, 1)).to eql(-4)
+      expect(redis.command("info", "hget").dig(0, 1)).to eql(3)
+      expect(redis.command("info", "hmset").dig(0, 1)).to eql(-4)
+      expect(redis.command("info", "hmget").dig(0, 1)).to eql(-3)
+      expect(redis.command("info", "hgetall").dig(0, 1)).to eql(2)
+    end
+  end
+
+  describe "commands used against the wrong type" do
+    let(:expected_error) { "WRONGTYPE Operation against a key holding the wrong kind of value" }
+
+    specify "raise an error" do
+      redis.set("x", "not a hash")
+
+      expect { redis.hset("x", "y", "z") }
+        .to raise_error(expected_error)
+      expect { redis.hget("x", "y") }
+        .to raise_error(expected_error)
+      expect { redis.hmset("x", "y", "z") }
+        .to raise_error(expected_error)
+      expect { redis.hmget("x", "y") }
+        .to raise_error(expected_error)
+      expect { redis.hgetall("x") }
+        .to raise_error(expected_error)
+    end
+  end
+end

--- a/tests/functional/hash_type_spec.rb
+++ b/tests/functional/hash_type_spec.rb
@@ -113,4 +113,23 @@ RSpec.describe "Hash commands", include_connection: true do
       end
     end
   end
+
+  describe "HGETALL" do
+    context "when the db key does not already exist" do
+      it "returns an empty array" do
+        # Underneath the client library, Redis returns an array
+        expect(redis.call("hgetall", "x")).to eql([])
+        # The client library knows to chunk the array in key value pairs to
+        # convert to a Ruby hash
+        expect(redis.hgetall("x")).to eql({})
+      end
+    end
+
+    context "when the db key already exists" do
+      it "returns an array of keys and values" do
+        redis.hmset("x", "y", "z", "1", "2")
+        expect(redis.hgetall("x")).to eql("y" => "z", "1" => "2")
+      end
+    end
+  end
 end

--- a/tests/functional/hash_type_spec.rb
+++ b/tests/functional/hash_type_spec.rb
@@ -2,8 +2,8 @@ RSpec.describe "Hash commands", include_connection: true do
   describe "arity" do
     specify "the arity for each command is correctly specified" do
       expect(redis.command("info", "hset").dig(0, 1)).to eql(-4)
-      expect(redis.command("info", "hget").dig(0, 1)).to eql(3)
       expect(redis.command("info", "hmset").dig(0, 1)).to eql(-4)
+      expect(redis.command("info", "hget").dig(0, 1)).to eql(3)
       expect(redis.command("info", "hmget").dig(0, 1)).to eql(-3)
       expect(redis.command("info", "hgetall").dig(0, 1)).to eql(2)
     end
@@ -76,6 +76,13 @@ RSpec.describe "Hash commands", include_connection: true do
           }.to raise_error("ERR wrong number of arguments for HMSET")
         end
       end
+    end
+  end
+
+  describe "HMSET" do
+    it "is identical to HSET except it has a different return value" do
+      expect(redis.hmset("x", "a", 1, "b", 2)).to eql("OK")
+      expect(redis.hmset("x", "a", 1, "c", 2)).to eql("OK")
     end
   end
 

--- a/tests/functional/hash_type_spec.rb
+++ b/tests/functional/hash_type_spec.rb
@@ -114,6 +114,21 @@ RSpec.describe "Hash commands", include_connection: true do
     end
   end
 
+  describe "HMGET" do
+    context "when the db key does not already exist" do
+      it "returns null" do
+        expect(redis.hmget("x", "y")).to eql([nil])
+      end
+    end
+
+    context "when the db key already exists" do
+      it "returns values where they are found or nil where they don't exist" do
+        redis.hmset("x", "a", "1", "c", "3")
+        expect(redis.hmget("x", "a", "b", "c")).to eql(["1", nil, "3"])
+      end
+    end
+  end
+
   describe "HGETALL" do
     context "when the db key does not already exist" do
       it "returns an empty array" do

--- a/tests/functional/keyspace_spec.rb
+++ b/tests/functional/keyspace_spec.rb
@@ -116,6 +116,11 @@ RSpec.describe "Keyspace commands", include_connection: true do
         redis.rpush("x", 1)
         expect(redis.type("x")).to eql("list")
       end
+
+      it "returns 'hash' for list types" do
+        redis.hset("x", "y", 1)
+        expect(redis.type("x")).to eql("hash")
+      end
     end
   end
 
@@ -156,15 +161,18 @@ RSpec.describe "Keyspace commands", include_connection: true do
           redis.set("a", "string")
           redis.rpush("b", %w[1 2])
           redis.set("c", 1)
+          redis.hset("d", "x", "y")
 
           if using_real_redis?
             expect(redis.object("encoding", "a")).to eql("embstr")
             expect(redis.object("encoding", "b")).to eql("quicklist")
             expect(redis.object("encoding", "c")).to eql("int")
+            expect(redis.object("encoding", "d")).to eql("ziplist")
           else
             expect(redis.object("encoding", "a")).to eql("byte_string")
             expect(redis.object("encoding", "b")).to eql("vecdeque")
             expect(redis.object("encoding", "c")).to eql("int")
+            expect(redis.object("encoding", "d")).to eql("hash_map")
           end
         end
       end

--- a/tests/functional/server_spec.rb
+++ b/tests/functional/server_spec.rb
@@ -46,7 +46,6 @@ RSpec.describe "Server commands", include_connection: true do
 
     describe "INFO" do
       it "returns the requested subset of supported commands" do
-        requested = %w[set get]
         output = redis.command("info", "set", "get")
         expect(output.count).to eql(2)
         expect(output[0].first).to eql("set")


### PR DESCRIPTION
# What?

Implements a "Hash" type with support for the following subset of commands:

- [x] `HSET`
- [x] `HMSET`
- [x] `HGET`
- [x] `HMGET`
- [x] `HGETALL`

# Why?

Required to support current goal of supporting just enough to run Sidekiq. See #1.

# How?

I have chosen to use Rust's `HashMap` type as a backing store.

Keys and values are `ByteString`s.

It's worth noting that [real Redis uses it's `sds` string type for values in Hashes](https://github.com/antirez/redis/blob/unstable/src/t_hash.c#L202). This means that to implement the HINCRBY command it has to [parse existing values back and forth from integers](https://github.com/antirez/redis/blob/unstable/src/t_hash.c#L559). This is in contrast to the string-type commands which encode wholy numeric strings as signed integers.
 
# Open issues

None.