### PR TITLE
Implement the EX and PX arguments for SET

### DIFF
--- a/scripts/watch-feature-tests
+++ b/scripts/watch-feature-tests
@@ -6,10 +6,14 @@
 # - "real" Redis (make sure it is running)
 # - Redis clone (make sure it is running or run the `watch-server` script)
 
+# Either pass a spec name as the first argument or it will default to watching
+# and running all specs.
+target="$1"
+
 cargo watch \
   --ignore-nothing \
   -w "$(pwd)/target/debug/redis-clone" \
-  -w "$(pwd)/tests/functional/hash_type_spec.rb" \
+  -w "$(pwd)/tests/functional/$target" \
   -s "cd $(pwd)/tests/functional" \
-  -s "TEST_REAL_REDIS=1 bin/rspec hash_type_spec.rb" \
-  -s "bin/rspec hash_type_spec.rb"
+  -s "TEST_REAL_REDIS=1 bin/rspec $target" \
+  -s "bin/rspec $target"

--- a/src/commands/string_type.rs
+++ b/src/commands/string_type.rs
@@ -11,18 +11,6 @@ use std::{
     time::{Duration, Instant},
 };
 
-macro_rules! parse_or_reply_with_err {
-    ($arg:expr, $resp:expr) => {
-        match $arg.parse() {
-            Ok(n) => n,
-            Err(_) => {
-                $resp.add_reply_not_a_number();
-                return Ok(());
-            }
-        };
-    };
-}
-
 pub(crate) fn set_command(
     db: &mut Database,
     request: &Request,

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -1,12 +1,19 @@
 #[macro_export]
-macro_rules! parse_arg_or_reply_with_err {
-    ($idx:literal, $req:expr, $resp:expr) => {
-        match $req.arg($idx)?.parse() {
+macro_rules! parse_or_reply_with_err {
+    ($arg:expr, $resp:expr) => {
+        match $arg.parse() {
             Ok(n) => n,
             Err(_) => {
                 $resp.add_reply_not_a_number();
                 return Ok(());
             }
         };
+    };
+}
+
+#[macro_export]
+macro_rules! parse_arg_or_reply_with_err {
+    ($idx:literal, $req:expr, $resp:expr) => {
+        parse_or_reply_with_err!($req.arg($idx)?, $resp)
     };
 }


### PR DESCRIPTION
# What?

Mainly:

* Implement the EX and PX arguments for SET

But also:

* Reorganise the tests for SET
* Add a test for empty keys and values
* Modify `watch-feature-tests` to remove hard coded test and parameterise

# Why?

Required to support current goal of supporting just enough to run Sidekiq. See #1.

# How?

Implemented by adding to the existing argument parsing code in `set_command`.

# Open issues

None.