### PR TITLE
Implement MSET and MGET

### DIFF
--- a/src/commands.rs
+++ b/src/commands.rs
@@ -50,6 +50,16 @@ static COMMAND_TABLE: &[RedisCommand] = &[
         arity: -3,
     },
     RedisCommand {
+        name: b"mget",
+        handler: string_type::mget_command,
+        arity: -2,
+    },
+    RedisCommand {
+        name: b"mset",
+        handler: string_type::mset_command,
+        arity: -3,
+    },
+    RedisCommand {
         name: b"del",
         handler: keyspace::del_command,
         arity: -2,

--- a/tests/functional/hash_type_spec.rb
+++ b/tests/functional/hash_type_spec.rb
@@ -70,7 +70,7 @@ RSpec.describe "Hash commands", include_connection: true do
       end
 
       context "when there is an uneven number of arguments" do
-        it "returns and error" do
+        it "returns an error" do
           expect {
             redis.call("hset", "x", "a", 2, "b")
           }.to raise_error("ERR wrong number of arguments for HMSET")


### PR DESCRIPTION
# What?

Implement MSET and MGET commands.

# Why?

Required to support current goal of supporting just enough to run Sidekiq. See #1.